### PR TITLE
Feature/show event

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,8 +10,8 @@ import { NewPage } from "../pages/new/new";
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 import { IonicStorageModule } from "@ionic/storage";
-import { ComponentsModule } from "../components/components.module";
 import { ShowPage } from "../pages/show/show";
+import { ComponentsModule } from "../components/components.module";
 
 @NgModule({
   declarations: [

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -2,14 +2,17 @@ import { NgModule } from '@angular/core';
 import { EventItemComponent } from './event-item/event-item';
 import { CommonModule } from "@angular/common";
 import { IonicModule } from "ionic-angular";
+import { TrackItemComponent } from './track-item/track-item';
 
 @NgModule({
-	declarations: [EventItemComponent],
+	declarations: [EventItemComponent,
+    TrackItemComponent],
 	imports: [
 	  CommonModule,
     IonicModule
   ],
-	exports: [EventItemComponent]
+	exports: [EventItemComponent,
+    TrackItemComponent]
 })
 
 export class ComponentsModule {}

--- a/src/components/track-item/track-item.html
+++ b/src/components/track-item/track-item.html
@@ -1,0 +1,12 @@
+<ion-grid>
+  <ion-row>
+    <ion-col col-10 class="track-title">
+      {{ track.name }}
+    </ion-col>
+    <ion-col col-2>
+      <button ion-fab color="secondary" mini (click)="play()">
+        <ion-icon name="play"></ion-icon>
+      </button>
+    </ion-col>
+  </ion-row>
+</ion-grid>

--- a/src/components/track-item/track-item.scss
+++ b/src/components/track-item/track-item.scss
@@ -1,0 +1,18 @@
+track-item {
+  .fab[mini] {
+    width: 27px;
+    height: 27px;
+    line-height: 27px;
+    font-size: 50%;
+    margin: 0;
+    float: right;
+  }
+
+  .fab ion-icon {
+    font-size: 1.5rem;
+  }
+
+  .track-title {
+    white-space:normal;
+  }
+}

--- a/src/components/track-item/track-item.ts
+++ b/src/components/track-item/track-item.ts
@@ -1,0 +1,36 @@
+import {Component, Input} from '@angular/core';
+import {TrackType} from "../../constants/types";
+import {AlertController} from "ionic-angular";
+
+/**
+ * Generated class for the TrackItemComponent component.
+ *
+ * See https://angular.io/api/core/Component for more info on Angular
+ * Components.
+ */
+@Component({
+  selector: 'track-item',
+  templateUrl: 'track-item.html'
+})
+export class TrackItemComponent {
+  @Input() track: TrackType;
+
+  constructor(private alertCtrl: AlertController) {
+  }
+
+  play() {
+    this.alert('track', 'track will be played on Spotify in a future update')
+  }
+
+  private alert(title: string, msg: string) {
+    const alert = this.alertCtrl.create({
+      title: title,
+      subTitle: msg,
+      buttons: ['Dismiss']
+    });
+    alert.present().catch((err) => {
+      console.log(err);
+    });
+  }
+
+}

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,5 +1,10 @@
 export type EventType = {
-  artist: String,
-  venue: String,
+  artist: string,
+  venue: string,
   datetime: Date,
+}
+
+export type TrackType = {
+  artist: string,
+  name: string
 }

--- a/src/pages/show/show.html
+++ b/src/pages/show/show.html
@@ -7,12 +7,30 @@
 <ion-header>
 
   <ion-navbar>
-    <ion-title>show</ion-title>
+    <ion-title>{{ event.artist }}</ion-title>
   </ion-navbar>
 
 </ion-header>
 
+<ion-content no-padding>
 
-<ion-content padding>
+  <ion-grid>
+    <ion-row>
+      <ion-col col-10 class="setlist-title">
+        <h1>Last setlist</h1>
+      </ion-col>
+      <ion-col col-2>
+        <button ion-fab color="primary" litle (click)="playTracklist()">
+          <ion-icon name="play"></ion-icon>
+        </button>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+
+  <ion-list>
+    <ion-item no-padding *ngFor="let track of tracks">
+      <track-item [track]="track"></track-item>
+    </ion-item>
+  </ion-list>
 
 </ion-content>

--- a/src/pages/show/show.scss
+++ b/src/pages/show/show.scss
@@ -1,3 +1,15 @@
 page-show {
+  .fab[litle] {
+    width: 40px;
+    height: 40px;
+    line-height: 40px;
+  }
 
+  .label-md {
+    margin: 0;
+  }
+
+  h1 {
+    margin: 0;
+  }
 }

--- a/src/pages/show/show.ts
+++ b/src/pages/show/show.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams } from 'ionic-angular';
+import {AlertController, NavController, NavParams} from 'ionic-angular';
+import {EventType, TrackType} from "../../constants/types";
 
 /**
  * Generated class for the ShowPage page.
@@ -13,13 +14,57 @@ import { NavController, NavParams } from 'ionic-angular';
   templateUrl: 'show.html',
 })
 export class ShowPage {
+  event: EventType;
+  tracks: TrackType[] = [
+    { artist: 'Within Temptation', name: 'She\'s in love with herself' },
+    { artist: 'Within Temptation', name: 'She likes the dark' },
+    { artist: 'Within Temptation', name: 'On her milk white neck' },
+    { artist: 'Within Temptation', name: 'The Devil\'s mark' },
+    { artist: 'Within Temptation', name: 'It\'s all Hallows Eve' },
+    { artist: 'Within Temptation', name: 'The moon is full' },
+    { artist: 'Within Temptation', name: 'Will she trick or treat' },
+    { artist: 'Within Temptation', name: 'I bet she will' },
+    { artist: 'Within Temptation', name: 'She\'s got date at midnight' },
+    { artist: 'Within Temptation', name: 'With Nosferatu' },
+    { artist: 'Within Temptation', name: 'Oh baby, Lilly Munster' },
+    { artist: 'Within Temptation', name: 'Ain\'t got nothing on you' },
+    { artist: 'Within Temptation', name: 'Well when I called her evil' },
+    { artist: 'Within Temptation', name: 'She just laughed' },
+    { artist: 'Within Temptation', name: 'And cast that spell on me' },
+    { artist: 'Within Temptation', name: 'Boo Bitch Craft' },
+    { artist: 'Within Temptation', name: 'Yeah you wanna go out \'cause it\'s raining and blowing' },
+    { artist: 'Within Temptation', name: 'You can\'t go out \'cause your roots are showing' },
+    { artist: 'Within Temptation', name: 'Dye em black' },
+    { artist: 'Within Temptation', name: 'Black no. 1' },
+    { artist: 'Within Temptation', name: 'Little wolf skin boots' },
+    { artist: 'Within Temptation', name: 'And clove cigarettes' },
+    { artist: 'Within Temptation', name: 'An erotic funeral' },
+    { artist: 'Within Temptation', name: 'For witch she\'s dressed' },
+    { artist: 'Within Temptation', name: 'Her perfume smells like' },
+    { artist: 'Within Temptation', name: 'Burning leaves' },
+    { artist: 'Within Temptation', name: 'Everyday is Halloween' },
+    { artist: 'Within Temptation', name: 'Loving you was like loving the dead' }
+  ];
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
-    console.log(navParams.get('event'))
+  constructor(public navCtrl: NavController,
+              public navParams: NavParams,
+              private alertCtrl: AlertController) {
+    this.event = navParams.get('event');
+    if (this.event == undefined) { this.navCtrl.goToRoot({}) }
   }
 
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad ShowPage');
+  playTracklist() {
+    this.alert('track', 'track will be played on Spotify in a future update')
   }
 
+  private alert(title: string, msg: string) {
+    const alert = this.alertCtrl.create({
+      title: title,
+      subTitle: msg,
+      buttons: ['Dismiss']
+    });
+    alert.present().catch((err) => {
+      console.log(err);
+    });
+  }
 }


### PR DESCRIPTION
# Objective

as **a user** I want to **see a setlist**

# Description

The whole goal of the application is to have an easy access to the last setlist and play it through spotify. This story have as such a goal to prepare the future implementation of setlist.fm. 

For now this story have to implement the actual page and a static setlist (rendered as if the data have been retrieve and not directly on the template, ie: fake data in the controller but actual template implementation).

The page have to retrieve the information from the persistent storage through an id parameter in the url.
(edit: it is passed directly with the router)

The template have to update the navigation bar tittle with the event name.

It also have to display the list of all track with their play button.

The general play button will for now display a toast displaying "The setlist will be played" and the single track play button "The track will be played"

A button to go to the previous screen have to be available in the navbar